### PR TITLE
Add FastAPI example with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/hello")
+def read_hello():
+    return {"message": "Hello World"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  api:
+    build: .
+    ports:
+      - "8000:8000"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]


### PR DESCRIPTION
## Summary
- create basic FastAPI app with a `/hello` endpoint
- add Dockerfile and requirements
- add docker-compose configuration to run the API

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*