### PR TITLE
Add scalable FastAPI + nginx skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Admin Dashboard Example
+
+This repository contains a minimal skeleton of a FastAPI backend with an
+Nginx front-end serving static pages. It demonstrates how a super admin can
+create admins and how admins can manage companies.
+
+## Development
+
+Build and run the services with docker-compose:
+
+```bash
+docker-compose up --build
+```
+
+The web interface is served on `http://localhost` and the API is available
+under `/api`.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,60 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import Dict, List
+
+app = FastAPI()
+
+# In-memory storage for demonstration
+super_admins: Dict[str, str] = {"admin": "admin"}  # username -> password
+admins: Dict[str, Dict[str, str]] = {}
+companies: List[Dict] = []
+
+class Login(BaseModel):
+    username: str
+    password: str
+
+class AdminCreate(BaseModel):
+    username: str
+    password: str
+
+class Company(BaseModel):
+    name: str
+    address: str
+    payday: str
+
+@app.post("/superadmin/login")
+def superadmin_login(credentials: Login):
+    if super_admins.get(credentials.username) == credentials.password:
+        return {"status": "logged_in"}
+    raise HTTPException(status_code=401, detail="Invalid credentials")
+
+@app.post("/superadmin/create_admin")
+def create_admin(admin: AdminCreate):
+    if admin.username in admins:
+        raise HTTPException(status_code=400, detail="Admin exists")
+    admins[admin.username] = {"password": admin.password, "companies": []}
+    return {"status": "admin_created"}
+
+@app.post("/admin/login")
+def admin_login(credentials: Login):
+    stored = admins.get(credentials.username)
+    if stored and stored["password"] == credentials.password:
+        return {"status": "logged_in"}
+    raise HTTPException(status_code=401, detail="Invalid credentials")
+
+@app.get("/admin/{username}/companies")
+def get_companies(username: str):
+    admin = admins.get(username)
+    if not admin:
+        raise HTTPException(status_code=404, detail="Admin not found")
+    return admin["companies"]
+
+@app.post("/admin/{username}/companies")
+def add_company(username: str, company: Company):
+    admin = admins.get(username)
+    if not admin:
+        raise HTTPException(status_code=404, detail="Admin not found")
+    company_data = company.dict()
+    admin["companies"].append(company_data)
+    companies.append(company_data)
+    return {"status": "company_added"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+services:
+  backend:
+    build: ./backend
+    container_name: backend
+    expose:
+      - "8000"
+  nginx:
+    build: ./nginx
+    ports:
+      - "80:80"
+    depends_on:
+      - backend

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY html /usr/share/nginx/html

--- a/nginx/html/index.html
+++ b/nginx/html/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Dashboard Login</title>
+</head>
+<body>
+    <h1>Login</h1>
+    <h2>Super Admin</h2>
+    <form action="/api/superadmin/login" method="post">
+        <input type="text" name="username" placeholder="username" />
+        <input type="password" name="password" placeholder="password" />
+        <button type="submit">Login</button>
+    </form>
+    <h2>Admin</h2>
+    <form action="/api/admin/login" method="post">
+        <input type="text" name="username" placeholder="username" />
+        <input type="password" name="password" placeholder="password" />
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,22 @@
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    server {
+        listen 80;
+
+        location /api/ {
+            proxy_pass http://backend:8000/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location / {
+            root /usr/share/nginx/html;
+            try_files $uri $uri/ =404;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move existing FastAPI code into `backend` directory
- create simple admin/super admin API with in-memory storage
- add nginx service and HTML front-end
- update docker-compose for backend + nginx
- provide basic README

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*